### PR TITLE
HC-245: Add capability to run the PGE step inline on the worker

### DIFF
--- a/chimera/commons/sciflo_util.py
+++ b/chimera/commons/sciflo_util.py
@@ -13,6 +13,8 @@ WORK_RE = re.compile(r'\d{5}-.+')
 def copy_sciflo_work(output_dir):
     """Move over smap_sciflo work dirs."""
 
+    # Instead of creating symlinks like it was initially doing, this has been updated
+    # to copy the sciflo workunit directories to its human readable sciflo step.
     for root, dirs, files in os.walk(output_dir):
         for d in dirs:
             if not WORK_RE.search(d):
@@ -20,11 +22,10 @@ def copy_sciflo_work(output_dir):
             path = os.path.join(root, d)
             if os.path.islink(path) and os.path.exists(path):
                 real_path = os.path.realpath(path)
-                base_name = os.path.basename(real_path)
+                os.unlink(path)
+                base_name = os.path.basename(path)
                 new_path = os.path.join(root, base_name)
                 shutil.copytree(real_path, new_path)
-                os.unlink(path)
-                os.symlink(base_name, path)
     return
 
 

--- a/chimera/pge_job_submitter.py
+++ b/chimera/pge_job_submitter.py
@@ -93,14 +93,6 @@ class PgeJobSubmitter(object):
 
         :return:
         """
-        # get HySDS job type and queue information
-        job_name = self._chimera_config.get(chimera_const.JOB_TYPES).get(self._pge_config.get(chimera_const.PGE_NAME))
-        if chimera_const.RELEASE_VERSION in self._context:
-            release_version = self._context[chimera_const.RELEASE_VERSION]
-        else:
-            release_version = self._context.get('container_specification').get('version')
-        job_type = job_name + ":" + release_version
-
         try:
             localize_urls = self.get_localize_urls(self._run_config.get(chimera_const.LOCALIZE))
         except Exception:
@@ -115,8 +107,7 @@ class PgeJobSubmitter(object):
             "simulate_outputs": self._run_config[chimera_const.SIMULATE_OUTPUTS]
         }
 
-        localize_hash = self.get_payload_hash(job_type)
-        return job_params, localize_hash
+        return job_params
 
     def get_payload_hash(self, job_type):
         """
@@ -193,6 +184,8 @@ class PgeJobSubmitter(object):
                 release_version = self._context.get('container_specification').get('version')
 
             job_type = job_name + ":" + release_version
+
+            localize_hash = self.get_payload_hash(job_type)
 
             # Find what the primary input is to the job
             # input_file_key = self._pge_config.get(chimera_const.PRIMARY_INPUT, None)

--- a/chimera/pge_job_submitter.py
+++ b/chimera/pge_job_submitter.py
@@ -31,14 +31,18 @@ class PgeJobSubmitter(object):
         self._pge_config = load_config(pge_config_file)
         logger.debug("Loaded PGE config file: {}".format(json.dumps(self._pge_config)))
 
+        self._wuid = wuid
+        self._job_num = job_num
+
         # load Settings file
         try:
             if settings_file:
                 settings_file = os.path.abspath(os.path.normpath(settings_file))
                 self._settings = YamlConf(settings_file).cfg
-                self._chimera_config = self._settings.get("CHIMERA")
-                if not self._chimera_config:
-                    raise RuntimeError("Must specify a CHIMERA area in {}".format(settings_file))
+                self._chimera_config = self._settings.get("CHIMERA", None)
+                if self._wuid and self._job_num:
+                    if not self._chimera_config:
+                        raise RuntimeError("Must specify a CHIMERA area in {}".format(settings_file))
         except Exception as e:
             if settings_file:
                 file_name = settings_file
@@ -47,8 +51,6 @@ class PgeJobSubmitter(object):
             raise RuntimeError("Could not read settings file '{}': {}".format(file_name, e))
 
         self._run_config = run_config
-        self._wuid = wuid
-        self._job_num = job_num
 
     def get_input_file_name(self, input_file_key=None):
         """

--- a/chimera/pge_job_submitter.py
+++ b/chimera/pge_job_submitter.py
@@ -167,7 +167,7 @@ class PgeJobSubmitter(object):
         if not isinstance(self._run_config, dict):
             raise RuntimeError("The output from input preprocessor is not a dictionary")
 
-        params, localize_hash = self.construct_params()
+        params = self.construct_params()
 
         # If wuid and job_num are not null, it is implied that we need to do job submission. In that case, we need to
         # construct the job payload.


### PR DESCRIPTION
Updated the job submitter such that it can support both the ability to run a PGE inline or by submitting a parallel job. This is done by checking the values of `wuid` and `job_num`. If the python binding is set to `parallel` in the sciflo workflow xml, then these values become non-null and the job submitter will go through it's steps of formulating the job payload for PGE job submission. On the other hand, if the python binding is set to a non-parallel binding, then this would imply that the job submitter should run the PGE job inline. The PGE wrapper can then be called within the adaptation's `perform_adaptation_tasks`.

Also made a change in how sciflo copies it's working directories back to the output directory. Previously, it created symlinks from a workflow unit directory to a human-readable directory name. But this would cause the output datasets to be ingested multiple times by Verdi, leading to un-necessary dedupes. The change here is basically to rename the workflow unit directory to it's human readable name. See attached screenshots in the Jira ticket for how the output looked like before and after this change.

Finally, a new variable named `base_work_dir` was added to the initialization of the job submitter class. This can be used to find other HySDS Core files in the working directory such as the `_docker_params.json`