### PR TITLE
HC-317: various improvements to the chimera precondition evaluator's runconfig preparation

### DIFF
--- a/chimera/commons/constants.py
+++ b/chimera/commons/constants.py
@@ -47,6 +47,9 @@ class ChimeraConstants(object):
     # primary input key in PGE config
     PRIMARY_INPUT = "primary_input"
 
+    # identifier token to specify empty runconfig values to be filled
+    EMPTY_FIELD_IDENTIFIER = "empty_field_identifier"
+
     # field to specify optionals runconfig fields
     OPTIONAL_FIELDS = "optionalFields"
 

--- a/chimera/precondition_evaluator.py
+++ b/chimera/precondition_evaluator.py
@@ -83,7 +83,7 @@ class PreConditionEvaluator(object):
                     # check if optionalField; if so, set value to empty string
                     if jp_key in optional_fields:
                         logger.info("Explicit dot notation key {} is an optional field.".format(jp_key))
-                        logger.info("Setting {} to value to empty string.".format(k))
+                        logger.info("Setting {} value to empty string.".format(k))
                         d[k] = ""
                     elif k in optional_fields:
                         logger.info("Key {} is an optional field.".format(k))

--- a/chimera/precondition_evaluator.py
+++ b/chimera/precondition_evaluator.py
@@ -126,12 +126,15 @@ class PreConditionEvaluator(object):
         :return: dict
         """
         logger.debug("Preparing runconfig for {}".format(self._pge_config.get('pge_name')))
+        empty_field_identifier = self._pge_config.get(ChimeraConstants.EMPTY_FIELD_IDENTIFIER,
+                                                      EMPTY_FIELD_IDENTIFIER)
+        logger.debug("Empty field identifier: {}".format(empty_field_identifier))
         output_context = dict()
         #TODO: how to incorporate optional_fields in recursive function
         #optional_fields = self._pge_config.get(ChimeraConstants.OPTIONAL_FIELDS, [])
         if self._pge_config.get(ChimeraConstants.RUNCONFIG):
             output_context = copy.deepcopy(self._pge_config.get(ChimeraConstants.RUNCONFIG))
-            matched_keys = self.repl_val_in_dict(output_context, EMPTY_FIELD_IDENTIFIER, job_params)
+            matched_keys = self.repl_val_in_dict(output_context, empty_field_identifier, job_params)
         else:
             raise KeyError("Key runconfig not found in PGE config file")
 

--- a/chimera/precondition_evaluator.py
+++ b/chimera/precondition_evaluator.py
@@ -87,7 +87,7 @@ class PreConditionEvaluator(object):
                         d[k] = ""
                     elif k in optional_fields:
                         logger.info("Key {} is an optional field.".format(k))
-                        logger.info("Setting {} to value to empty string.".format(k))
+                        logger.info("Setting {} value to empty string.".format(k))
                         d[k] = ""
                     else:
                         logger.error("job_params: {}".format(json.dumps(job_params, indent=2, sort_keys=True)))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ adaptation_path = "folder/"
 
 setup(
     name='chimera',
-    version='2.1.3',
+    version='2.1.4',
     packages=find_packages(),
     install_requires=[
         'elasticsearch>=7.0.0,<8.0.0',


### PR DESCRIPTION
This PR updates the `prepare_runconfig()` method so that:

- the `EMPTY_FIELD_IDENTIFIER` is modified from `None` to `__CHIMERA_VAL__`
  - this will allow for `null` or empty values in the PGE config's runconfig and not signal them for replacement via a job_param value which may otherwise cause value errors (see `list_of_frequencies` below)
- the PGE config's runconfig is search recursively (more than 2 levels deep) for values to be replaced via the `EMPTY_FIELD_IDENTIFIER`
- when a value in the runconfig needs to be replaced with a value from job_params (because it has `__CHIMERA_VAL__` set in the PGE config), it first searches for the full dot-notation key in the job_params and falls back to the previous behavior of the local key. For example, the PGE_GCOV.yaml specifies:
```
runconfig:
...
  processing:
    input_subset:
      list_of_frequencies:
        A:
      fullcovariance: "__CHIMERA_VAL__"
```
The `prepare_runconfig()` will first look for the key `processing.input_subset.fullcovariance` in the job_params dict and if not found will fallback to the previous behavior and look for `fullcovariance`. This is so that runconfig parameter names that are in multiple places can be specifically targeted.

This feature was tested and verified manually using the `dev-e2e-pge` test on a NISAR dev cluster and the corresponding feature branch `NSDS-1157-1135-1140`.