### PR TITLE
handle localizing files in dict

### DIFF
--- a/chimera/precondition_evaluator.py
+++ b/chimera/precondition_evaluator.py
@@ -121,6 +121,12 @@ class PreConditionEvaluator(object):
                         if is_url(v):
                             localize_paths_list.append(v)
 
+                elif isinstance(value, dict):
+                    for v in value:
+                        url = value.get(v)
+                        if is_url(url):
+                            localize_paths_list.append(url)
+
                 elif isinstance(value, str):
                     if is_url(value):
                         localize_paths_list.append(value)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ adaptation_path = "folder/"
 
 setup(
     name='chimera',
-    version='2.2.2',
+    version='2.2.3',
     packages=find_packages(),
     install_requires=[
         'elasticsearch>=7.0.0,<7.14.0',


### PR DESCRIPTION
This hotfix PR addresses an issue where a runconfig can include files to localize using a dict but the files are never localized, e.g.:
```
    dynamic_ancillary_file_group:
      orbit_files:
        reference_orbit_file: /data/work/jobs/2023/10/12/22/04/SCIFLO_INSAR__develop-network_pair_013_016_055_full_individual_L_20_DH_05_DH_state-config-20231012T220022.178969Z/NISAR_ANC_J_PR_POE_20221001T012345_20220108T000000_20220108T235959.xml
        secondary_orbit_file: /data/work/jobs/2023/10/12/22/04/SCIFLO_INSAR__develop-network_pair_013_016_055_full_individual_L_20_DH_05_DH_state-config-20231012T220022.178969Z/NISAR_ANC_J_PR_POE_20230329T145019_20220205T005942_20220205T225942.xml
```

This hotfix was verified in a manually deployed cluster (see `*POE*xml` files now exist in work directory):
```
$ ls -ltr
total 57818108
-rw-r--r-- 1 ops  ops         3527 Oct 12 22:07 _docker_params.json
-rwxr-xr-x 1 root root           0 Oct 12 22:09 datasets.json
-rwxr-xr-x 1 root root           0 Oct 12 22:09 celeryconfig.py
-rw-r--r-- 1 ops  ops       130413 Oct 12 22:28 _job.json
-rw-r--r-- 1 ops  ops       198487 Oct 12 22:28 _datasets.json
-rwxr-xr-x 1 ops  ops         4419 Oct 12 22:29 _run.sh
-rw-r--r-- 1 ops  ops            6 Oct 12 22:55 _pid
-rwxr-xr-x 1 ops  ops          315 Oct 12 22:55 rerun.sh
-rw-r--r-- 1 ops  ops            2 Oct 12 22:55 _docker_stats_hold.json
-rw-r--r-- 1 ops  ops         1001 Oct 12 22:55 _alt_traceback_hold.txt
-rw-r--r-- 1 ops  ops         1001 Oct 12 22:55 _alt_error_hold.txt
-rw-r--r-- 1 ops  ops   1309857174 Oct 12 22:56 dem_0.tiff
-rw-r--r-- 1 ops  ops         1316 Oct 12 22:56 dem.vrt
-rw-r--r-- 1 ops  ops    221658478 Oct 12 22:59 WATERMASK_0.tiff
-rw-r--r-- 1 ops  ops         1148 Oct 12 22:59 WATERMASK.vrt
-rw-r--r-- 1 ops  ops   7130349648 Oct 12 23:00 A2D01080600010806001.nc
-rw-r--r-- 1 ops  ops   7340064856 Oct 12 23:02 A3D01080600010806001.nc
-rw-r--r-- 1 ops  ops  14365524300 Oct 12 23:03 D01080600010806001.nc
-rw-r--r-- 1 ops  ops   7130349648 Oct 12 23:06 A2D02050600020506001.nc
-rw-r--r-- 1 ops  ops   7340064856 Oct 12 23:08 A3D02050600020506001.nc
-rw-r--r-- 1 ops  ops  14365524300 Oct 12 23:09 D02050600020506001.nc
-rw-r--r-- 1 ops  ops          354 Oct 12 23:11 NISAR_ANC_J_PR_POE_20221001T012345_20220108T000000_20220108T235959.xml
-rw-r--r-- 1 ops  ops         1024 Oct 12 23:11 NISAR_L1_PR_RSLC_013_016_D_055_2005_DHDH_A_20220205T083534_20220205T083611_D00340_P_F_J_001.h5
-rw-r--r-- 1 ops  ops         1024 Oct 12 23:11 NISAR_L1_PR_RSLC_001_016_D_055_2005_DHDH_A_20220108T083534_20220108T083611_D00340_P_F_J_001.h5
-rw-r--r-- 1 ops  ops          354 Oct 12 23:11 NISAR_ANC_J_PR_POE_20230329T145019_20220205T005942_20220205T225942.xml
-rw-r--r-- 1 ops  ops       688987 Oct 12 23:11 NISAR_ANC_L_TEC_20230926T144500_20220205T000000_20220205T235900_v0.0.json
-rw-r--r-- 1 ops  ops         4735 Oct 12 23:11 pge_metrics.json
-rw-r--r-- 1 ops  ops        61743 Oct 12 23:11 _context.json
drwxr-xr-x 2 ops  ops           37 Oct 12 23:11 pge_stats
-rw-r--r-- 1 ops  ops         4555 Oct 12 23:11 RunConfig.yaml
drwxr-xr-x 3 ops  ops         4096 Oct 12 23:11 output
drwxr-xr-x 5 ops  ops         4096 Oct 12 23:11 sfl_output
-rw-r--r-- 1 ops  ops      1149826 Oct 12 23:11 run_sciflo_INSAR.log
```