### PR TITLE
HC-522-update: Updates to support moving away from OPS user

### DIFF
--- a/chimera/commons/sciflo_util.py
+++ b/chimera/commons/sciflo_util.py
@@ -2,7 +2,7 @@
 import os
 import json
 import re
-import shutil
+import subprocess
 
 WORK_RE = re.compile(r"\d{5}-.+")
 
@@ -99,7 +99,10 @@ def copy_sciflo_work(output_dir):
                 os.unlink(path)
                 base_name = os.path.basename(path)
                 new_path = os.path.join(root, base_name)
-                shutil.copytree(real_path, new_path)
+                try:
+                    subprocess.run(["cp", "-R", real_path, new_path], check=True, text=True, capture_output=True)
+                except subprocess.CalledProcessError as e:
+                    print(f"Error occurred during copy: return code = {e.returncode}\n{e.stderr}")  # captures stderr output
     return
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ adaptation_path = "folder/"
 
 setup(
     name='chimera',
-    version='2.2.3',
+    version='2.2.4',
     packages=find_packages(),
     install_requires=[
         'elasticsearch>=7.0.0,<7.14.0',

--- a/tests/test_input_preprocessor.py
+++ b/tests/test_input_preprocessor.py
@@ -1,5 +1,5 @@
 import simplejson
-from nisar_chimera import input_preprocessor as ipp
+from chimera import input_preprocessor as ipp
 
 if __name__ == '__main__':
     sys_config = "../nisar_chimera/configs/sys.config.json"
@@ -7,16 +7,17 @@ if __name__ == '__main__':
 
     # For testing without sfl_exec L0A
     context = simplejson.load(
-        open("test-files/L0A_sfcontext.json", 'r'))
-    ipp_def_filepath = "../nisar_chimera/configs/precondition_definition.yaml"
-    pge_config = "../nisar_chimera/configs/pge_configs/PGE_L0A.yaml"
-    settings_file = '../../nisar-pcm/conf/settings.yaml'
+        open("test-files/L0B_datatake.json", 'r'))
+    #ipp_def_filepath = "../nisar_chimera/configs/precondition_definition.yaml"
+    chimera_config = "/Users/mcayanan/git/nisar-pcm/nisar_chimera/configs/chimera_config.yaml"
+    pge_config = "/Users/mcayanan/git/nisar-pcm/nisar_chimera/configs/pge_configs/PGE_L0B.yaml"
+    settings_file = '/Users/mcayanan/git/nisar-pcm/conf/settings.yaml'
     test_configs.append((context, pge_config))
 
     # context = process_for_l0b_radiometer(context, simplejson.load(open(pge_config, 'r')))
     # Loop through all test configs
     for context, pge_config in test_configs:
-        payload = ipp.process(sf_context=context, ipp_def_filepath=ipp_def_filepath, pge_config_filepath=pge_config,
-                              sys_config_file=sys_config, settings_file=settings_file, testmode=True)
+        payload = ipp.process(sf_context=context, chimera_config_file=chimera_config, pge_config_filepath=pge_config,
+                              settings_file=settings_file)
 
-    print(simplejson.dumps(payload, indent=2))
+        print(simplejson.dumps(payload, indent=2))


### PR DESCRIPTION
This PR updates the way that Chimera copies the sciflo work directories from /tmp to the job working directory at the Verdi level. It was found through testing that because of SELinux, the SELinux object labels ended up being different, which caused permission issues when trying to access the copied sciflo working directores from the httpd server:

![image](https://github.com/user-attachments/assets/1851af22-692c-4911-88a3-041bb1d4035a)

Switching to a system cp call ended up being the solution because with the cp command, it updates the SElinux object to be consistent with the target directory:

![image](https://github.com/user-attachments/assets/9e447b1b-7dfb-4880-8381-82e1998b64db)
