### PR TITLE
HC-599: Update context field path to use job.context

### DIFF
--- a/chimera/postprocess_functions.py
+++ b/chimera/postprocess_functions.py
@@ -181,7 +181,7 @@ class PostProcessFunctions:
                 products_staged = orig_job_info["_source"]["job"]["job_info"][
                     "metrics"
                 ]["products_staged"]
-                prev_context = orig_job_info["_source"]["context"]
+                prev_context = orig_job_info["_source"]["job"]["context"]
                 logger.info("Queried ES to get Job context and staged files info")
                 message = "success"
         elif status == "job-completed":
@@ -189,7 +189,7 @@ class PostProcessFunctions:
             products_staged = result["_source"]["job"]["job_info"]["metrics"][
                 "products_staged"
             ]
-            prev_context = result["_source"]["context"]
+            prev_context = result["_source"]["job"]["context"]
             logger.info("Queried ES to get Job context and staged files info")
             message = "success"
             return_job_id = job_id

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ adaptation_path = "folder/"
 
 setup(
     name='chimera',
-    version='2.3.0',
+    version='3.0.0',
     python_requires=">=3.12",
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
## Summary

This PR updates chimera to read `prev_context` from `job.context` instead of the top-level `context` field in job_status documents. This is a companion change to [HC-598](https://hysds-core.atlassian.net/browse/HC-598) which removes the duplicate top-level `context` field from HySDS.

**For full details, test artifacts, and deployment instructions, see the HySDS PR for [HC-598](https://github.com/hysds/hysds/pull/212).**

## Related Tickets

- **[HC-599](https://hysds-core.atlassian.net/browse/HC-599)** - Chimera: Update context field path to use job.context
- **[HC-598](https://hysds-core.atlassian.net/browse/HC-598)** - HySDS: Remove duplicate context field from job_status documents

## Changes

### File: `chimera/postprocess_functions.py`

Updated two locations where `prev_context` is retrieved from Elasticsearch job_status documents:

```diff
- prev_context = orig_job_info["_source"]["context"]
+ prev_context = orig_job_info["_source"]["job"]["context"]
```

```diff
- prev_context = result["_source"]["context"]
+ prev_context = result["_source"]["job"]["context"]
```

**Lines changed:**
- Line 184: deduped job case (`orig_job_info`)
- Line 192: completed job case (`result`)

## Backward Compatibility

This change is **fully backward compatible**:

| Document Type | `context` field | `job.context` field | This PR reads from |
|---------------|-----------------|---------------------|-------------------|
| Old documents | Present | Present (identical) | `job.context` |
| New documents (with HC-598) | Not present | Present | `job.context` |

## Deployment Order

1. **Deploy this chimera PR (HC-599) first**
2. Then deploy HySDS PR (HC-598)

See HC-598 PR for complete deployment documentation.

## Checklist

- [x] Code changes are minimal and focused
- [x] Backward compatible with existing job_status documents
- [x] Forward compatible with HC-598 changes
- [x] No security implications

[HC-598]: https://hysds-core.atlassian.net/browse/HC-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HC-598]: https://hysds-core.atlassian.net/browse/HC-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HC-599]: https://hysds-core.atlassian.net/browse/HC-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HC-598]: https://hysds-core.atlassian.net/browse/HC-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ